### PR TITLE
Argoniens DragNDropPatch

### DIFF
--- a/src/dragndrop.c
+++ b/src/dragndrop.c
@@ -1,0 +1,93 @@
+#include <pmdsky.h>
+#include <cot.h>
+#include "extern.h"
+
+//I'm pretty sure VAR_SIDE06_ROOM is not used elsewhere in this repository?
+static void ChangePressBit(){
+  int check = LoadScriptVariableValue(NULL, VAR_SIDE06_ROOM);
+  if (check == 0){
+  SaveScriptVariableValue(NULL, VAR_SIDE06_ROOM, 1);// 1= write, 0 = check
+  }
+  else if(check == 1){
+    SaveScriptVariableValue(NULL, VAR_SIDE06_ROOM, 0);
+  }
+}
+
+static int checkIfTsValuesAreInDefinedRange(short arg1){
+  int TSX = TSXPosLive;
+  int TSY = TSYPosLive;
+  int TSP = TSPressed;
+  TSX = TSX*256;
+  TSY = TSY*256;//TS Values Set Up
+  int TSBitcheck = LoadScriptVariableValue(NULL, VAR_SIDE06_ROOM);
+  if (TSBitcheck == 0){
+  if (TSP == 0){
+    return 255;
+  }
+  //Check for Index 0
+  int XInd = LoadScriptVariableValueAtIndex(NULL, VAR_POSITION_X, 0);
+  int YInd = LoadScriptVariableValueAtIndex(NULL, VAR_POSITION_Y, 0);
+  if (TSX < XInd+2560 && TSX > XInd-2560 && TSY > YInd-5120 && TSY+512  < YInd){
+    ChangePressBit();
+    return 0;
+  }
+  //Check for Index 1
+  XInd = LoadScriptVariableValueAtIndex(NULL, VAR_POSITION_X, 1);
+  YInd= LoadScriptVariableValueAtIndex(NULL, VAR_POSITION_Y, 1);
+  if (TSX < XInd+2560 && TSX > XInd-2560 && TSY > YInd-5120 && TSY+512  < YInd){
+    ChangePressBit();
+    return 1;
+  }
+  //Check for Index 2
+  XInd = LoadScriptVariableValueAtIndex(NULL, VAR_POSITION_X, 2);
+  YInd= LoadScriptVariableValueAtIndex(NULL, VAR_POSITION_Y, 2);
+  if (TSX < XInd+2560 && TSX > XInd-2560 && TSY > YInd-5120 && TSY+512 < YInd){
+    ChangePressBit();
+    return 2;
+  }
+  return 254;
+  }
+  else{
+    if (TSP == 0){
+      //Save last pos after drag
+      int TSXLast = TSXPosLastMitDrag;
+      int TSYLast = TSYPosLastMitDrag;
+      TSXLast = TSXLast*256;
+      TSYLast = TSYLast*256;
+      switch (arg1){
+        case 0:
+        SaveScriptVariableValueAtIndex(NULL, VAR_POSITION_X, 0, TSXLast);
+        SaveScriptVariableValueAtIndex(NULL, VAR_POSITION_Y, 0, TSYLast);
+        ChangePressBit();
+        return 2;
+        case 1:
+        SaveScriptVariableValueAtIndex(NULL, VAR_POSITION_X, 1, TSXLast);
+        SaveScriptVariableValueAtIndex(NULL, VAR_POSITION_Y, 1, TSYLast);
+        ChangePressBit();
+        return 2;
+        case 2:
+        SaveScriptVariableValueAtIndex(NULL, VAR_POSITION_X, 2, TSXLast);
+        SaveScriptVariableValueAtIndex(NULL, VAR_POSITION_Y, 2, TSYLast);
+        ChangePressBit();
+        return 2;
+      }
+      return 2;
+    }
+
+    switch (arg1){
+      case 0:
+      SaveScriptVariableValueAtIndex(NULL, VAR_POSITION_X, 0, TSX);
+      SaveScriptVariableValueAtIndex(NULL, VAR_POSITION_Y, 0, TSY);
+      return 1;
+      case 1:
+      SaveScriptVariableValueAtIndex(NULL, VAR_POSITION_X, 1, TSX);
+      SaveScriptVariableValueAtIndex(NULL, VAR_POSITION_Y, 1, TSY);
+      return 1;
+      case 2:
+      SaveScriptVariableValueAtIndex(NULL, VAR_POSITION_X, 2, TSX);
+      SaveScriptVariableValueAtIndex(NULL, VAR_POSITION_Y, 2, TSY);
+      return 1;
+    }
+  return 128;
+  }
+}

--- a/src/extern.h
+++ b/src/extern.h
@@ -108,3 +108,10 @@ struct EngineDisplayInfo {
     bool disable_obj;
 };
 extern struct EngineDisplayInfo ENGINE_DISPLAY_INFO[2];
+
+//Touchscreen Variables
+extern uint8_t TSXPosLive;
+extern uint8_t TSYPosLive;
+extern uint8_t TSXPosLastMitDrag;
+extern uint8_t TSYPosLastMitDrag;
+extern uint8_t TSPressed;

--- a/src/special_processes.c
+++ b/src/special_processes.c
@@ -2,6 +2,7 @@
 #include <cot.h>
 #include "extern.h"
 #include "top_screen_management.h"
+#include "dragndrop.c"
 
 bool process_has_been_called_once = false;
 
@@ -125,6 +126,11 @@ bool CustomScriptSpecialProcessCall(undefined4* unknown, uint32_t special_proces
       initDrawingOnTopScreen(temppath);
       return true;
     
+    //Argoniens DragNDrop Patch
+    case 115:
+      *return_val = checkIfTsValuesAreInDefinedRange(arg1);
+      return true;
+
     case 254:
       *return_val = SpCreateSpecialWindow(arg1, arg2);
       return true;

--- a/symbols/custom_NA.ld
+++ b/symbols/custom_NA.ld
@@ -63,3 +63,10 @@ ENGINE_DISPLAY_INFO = 0x022A37AC; # EU: 0x020091c8
 # Hook at the start of the frame, when it’s safe to write to the VRAM
 FrameHookStart = 0x022e930c; # EU: 0x022e9c4c
 FrameHookCallAtEnd = 0x02008f88; # EU: 0x02008f88 (the same)
+
+/* !file ram */
+TSXPosLive = 0x22A35DC;
+TSYPosLive = 0x22A35E0;
+TSPressed = 0x22A35E4;
+TSXPosLastMitDrag = 0x22A35FC;
+TSYPosLastMitDrag = 0x22A3600;

--- a/symbols/custom_NA.ld
+++ b/symbols/custom_NA.ld
@@ -63,10 +63,3 @@ ENGINE_DISPLAY_INFO = 0x022A37AC; # EU: 0x020091c8
 # Hook at the start of the frame, when it’s safe to write to the VRAM
 FrameHookStart = 0x022e930c; # EU: 0x022e9c4c
 FrameHookCallAtEnd = 0x02008f88; # EU: 0x02008f88 (the same)
-
-/* !file ram */
-TSXPosLive = 0x22A35DC;
-TSYPosLive = 0x22A35E0;
-TSPressed = 0x22A35E4;
-TSXPosLastMitDrag = 0x22A35FC;
-TSYPosLastMitDrag = 0x22A3600;


### PR DESCRIPTION
A Patch that allows for Dragging and Dropping Actors and Objects.
Should be compatible with all common emulators and hardware.
Only works correctly in the top left of the screen (default position).